### PR TITLE
Carthage support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-VinceRP
+VinceRP [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 ======================================
 An easy to use, easy to extend reactive framework for Swift.
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@ An easy to use, easy to extend reactive framework for Swift.
 
 Getting Started
 -----------------
-1. `brew install carthage`
-2. `carthage update --platform ios`
+
+Install with [Carthage](https://github.com/Carthage/Carthage):
+
+1. `brew update && brew install carthage`
+2. `carthage update --platform iOS`
 
 OS X, tvOS and watchOS not yet tested/supported.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,19 @@ An easy to use, easy to extend reactive framework for Swift.
 Getting Started
 -----------------
 
-Install with [Carthage](https://github.com/Carthage/Carthage):
+Install with [Carthage](https://github.com/Carthage/Carthage)
 
-1. `brew update && brew install carthage`
-2. `carthage update --platform iOS`
+1. Add VinceRP to your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
+
+`github "bvic23/VinceRP"`
+
+2. Update & install `carthage`:
+
+`brew update && brew install carthage`
+
+3. Set it up as a dependency to your project:
+
+`carthage update --platform iOS`
 
 OS X, tvOS and watchOS not yet tested/supported.
 

--- a/vincerp.xcodeproj/xcshareddata/xcschemes/vincerp.xcscheme
+++ b/vincerp.xcodeproj/xcshareddata/xcschemes/vincerp.xcscheme
@@ -22,10 +22,10 @@
          </BuildActionEntry>
          <BuildActionEntry
             buildForTesting = "YES"
-            buildForRunning = "YES"
+            buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "79F2568B1ADE77250077730C"


### PR DESCRIPTION
Modified scheme to remove `run` and `analyze` from build test target. This way Carthage won't look for test target dependencies.
