### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Easy to use, easy to extend reactive framework for Swift.
 [![codecov.io](http://codecov.io/github/bvic23/VinceRP/coverage.svg?branch=master)](http://codecov.io/github/bvic23/VinceRP?branch=master)
 [![MIT License](https://img.shields.io/badge/license-MIT%20License-blue.svg)](LICENSE)
 
-#Getting Started
+# Getting Started
 
 The framework supports iOS & Mac for now.
 
-##Compatibility
+## Compatibility
 
 - Swift 2.x
 - iOS 8.3 and up
@@ -22,9 +22,9 @@ The framework supports iOS & Mac for now.
 
 > tvOS and watchOS not yet tested/supported.
 
-##Install
+## Install
 
-###[Carthage](https://github.com/Carthage/Carthage)
+### [Carthage](https://github.com/Carthage/Carthage)
 
 1. Add VinceRP to your
 [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile): `github "bvic23/VinceRP"`
@@ -34,7 +34,7 @@ The framework supports iOS & Mac for now.
 3. Set VinceRP up as a dependency to your project:
 `carthage update --platform iOS, Mac`
 
-###[CocoaPods](https://cocoapods.org/)
+### [CocoaPods](https://cocoapods.org/)
 
 1. Add VinceRP to your
 [Podfile](https://guides.cocoapods.org/syntax/podfile.html): `pod 'VinceRP'`
@@ -43,7 +43,7 @@ The framework supports iOS & Mac for now.
 
 3. Run: `pod install`
 
-#Easy to use
+# Easy to use
 
 Let's see a basic example:
 
@@ -91,7 +91,7 @@ let s3 = definedAs{ s2* + s* }
 ```
 You might see a weird error message but it's all about the missing `<string> + <int>` operator.
 
-##Side effects
+## Side effects
 
 Of course you can have side effects:
 
@@ -132,7 +132,7 @@ s <- 2
 print(counter) //  1
 ```
 
-##Errors
+## Errors
 
 If you're interested in errors:
 
@@ -159,9 +159,9 @@ s <- NSError(domain: "test error", code: 1, userInfo: nil)
 // Error Domain=test error Code=1 "(null)"
 ```
 
-#Operators
+# Operators
 
-###not
+### not
 
 It is applicable for `Bool` streams and negates the values.
 
@@ -176,7 +176,7 @@ print(a.value()) //  true
 print(a.not().value()) //  false
 ```
 
-###distinct
+### distinct
 
 ```swift
 // Define a reactive stream variable with '1' as initial value
@@ -206,7 +206,7 @@ print(c) //  1
 
 ```
 
-###skipErrors
+### skipErrors
 
 ```swift
 // Define a reactive stream variable
@@ -228,7 +228,7 @@ x <- NSError(domain: "domain.com", code: 1, userInfo: nil)
 print(count) // 0
 ```
 
-###foreach
+### foreach
 ```swift
 // Define a reactive stream variable with a starting value of 1
 let x = reactive(1)
@@ -251,7 +251,7 @@ x <- 2
 print(accu) // [1, 2]
 ```
 
-###map
+### map
 ```swift
 // Define a reactive stream variable with a starting value of 1
 let x = reactive(1)
@@ -269,7 +269,7 @@ x <- 2
 print(y) // 4
 ```
 
-###mapAll
+### mapAll
 `mapAll` is a special version of map which operates on [Try<T>](https://github.com/bvic23/VinceRP/blob/master/vincerp/Common/Util/Try.swift), the underlying monad if you want to handle Failures in some special way.
 
 Let's say we would like to have an error if division by zero is happening:
@@ -314,7 +314,7 @@ denominator <- 2
 // divison by zero
 // 2
 ```
-###filter
+### filter
 
 ```swift
 // Define a reactive stream variable with a starting value of 10
@@ -336,7 +336,7 @@ x <- 6
 print(y*) // 6
 ```
 
-###filterAll
+### filterAll
 `filterAll` is a special version of map which operates on [Try<T>](https://github.com/bvic23/VinceRP/blob/master/vincerp/Common/Util/Try.swift), the underlying monad if you want to handle Failures in some special way.
 
 Let's implement `skipErrors` in terms of `filterAll`:
@@ -347,7 +347,7 @@ public func skipErrors() -> Hub<T> {
 }
 ```
 
-###reduce
+### reduce
 
 ```swift
 // Define a reactive stream variable with a starting value of 1
@@ -369,7 +369,7 @@ x <- 3
 print(sum*) // 6
 ```
 
-###reduceAll
+### reduceAll
 `reduceAll` is a special version of map which operates on [Try<T>](https://github.com/bvic23/VinceRP/blob/master/vincerp/Common/Util/Try.swift), the underlying monad if you want to handle Failures in some special way.
 
 ```swift
@@ -413,7 +413,7 @@ expect(sum*) == 5
 
 ```
 
-###ignore
+### ignore
 `ignore` is simply a filter against a constant value:
 
 ```swift
@@ -440,7 +440,7 @@ x <- 5
 print(y*) // 5
 ```
 
-###throttle
+### throttle
 `throttle` operator buffers an item from the stream and wait for the time span specified by the timeout parameter to expire. If another item is produced from the sequence before the time span expires, Then that item replaces the old item in the buffer and the wait starts over. If the due time does expire before another item is produced in the stream, them that item is observed through any subscriptions to the sequence.
 
 ```swift
@@ -465,7 +465,7 @@ print(y*) // 1
 
 For a better example, check out the [FlickrExample](https://github.com/bvic23/VinceRP/tree/master/examples/BasicExample)
 
-#Easy to extend
+# Easy to extend
 
 It's pretty easy to add reactive properties to UIKit with extensions:
 
@@ -512,19 +512,19 @@ extension UITextField {
 
 Whenever the value of the `reactiveText` property changes it recalculates the value of `isValidEmail` property automagically.
 
-#About
+# About
 
 VinceRP is in alpha phase so please use it carefully in production and push me [mail](bvic23@gmail.com)/[tweet](@bvic23)/github issue to make me happy and proud! :-)
 
-##Do you miss something?
+## Do you miss something?
 
 Add it, ask for it... Any suggestions, bug reports, in the form of [issues](https://github.com/bvic23/VinceRP/issues) and of course [pull requests](https://github.com/bvic23/VinceRP/pulls) are welcome!
 
-##Who is Vince?
+## Who is Vince?
 
 [![Vince](https://scontent-vie1-1.cdninstagram.com/hphotos-xaf1/t51.2885-15/e15/10919568_846220368758561_908103058_n.jpg)](http://instagram.com/the_sphynx_and_the_prince)
 
-#References
+# References
 
 * [Reactive Extensions](https://msdn.microsoft.com/en-us/data/gg577609.aspx)
 * [RxJava](https://github.com/ReactiveX/RxJava)
@@ -551,6 +551,6 @@ Add it, ask for it... Any suggestions, bug reports, in the form of [issues](http
 * [Controlling Complexity in Swift](https://realm.io/news/andy-matuschak-controlling-complexity/)
 * [ReactKit](https://github.com/ReactKit/ReactKit)
 
-#License
+# License
 
 [VinceRP is released under an MIT license.](https://github.com/bvic23/VinceRP/blob/master/LICENSE)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
